### PR TITLE
Add the completed categorizations to the repo

### DIFF
--- a/ARTS_categorization/ARTS_PositivePolygons_20250626.geojson
+++ b/ARTS_categorization/ARTS_PositivePolygons_20250626.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4777047d021d19388bc727c411a40ea06968cafdf2929761b13904243cc26d
+size 98

--- a/ARTS_categorization/ARTS_PositivePolygons_Categorized_20250804.geojson
+++ b/ARTS_categorization/ARTS_PositivePolygons_Categorized_20250804.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcc7fe6dd33166d2478392d973daa928af3cd73129ae8904cf9ccacba7bff61d
+size 57977426


### PR DESCRIPTION
This is where Marly will store versions of the ARTS positive polygons categorizations as she progresses. The attribute table has columns for mismatch type, difficulty to fix, date of imagery, and comments. This last version has 9,328 categorized polygons out of 19,314. All 19,314 are now completed.